### PR TITLE
Use the widget title of ROLE for IWC instead of <head><title>

### DIFF
--- a/TestWidgets/frontendComponent-TestWidget/js/lib/iwc.js
+++ b/TestWidgets/frontendComponent-TestWidget/js/lib/iwc.js
@@ -172,7 +172,7 @@
 			console.log(intent);
 			var frames = $(".widget", parent.document).find("iframe");
 			frames.each(function () {
-				if ($(this).contents().find("head").find("title").text() === intent.receiver) {
+				if ($('.widget-title-bar', this.offsetParent).find('span').text() === intent.receiver) {
 					this.contentWindow.postMessage(intent, origin);
 				}
 			});
@@ -232,6 +232,11 @@
 			}
 			return true;
 		};
+
+		/**
+		 * Contains the title of the widget
+		 */
+		IWC.util.Self = $('.widget-title-bar', frameElement.offsetParent).find('span').text();
 
 		return IWC;
 	}

--- a/TestWidgets/frontendComponent-TestWidget/widget.xml
+++ b/TestWidgets/frontendComponent-TestWidget/widget.xml
@@ -58,7 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>TestWidget</title>
+  <title>TestWidget (Not used for IWC!)</title>
 
   <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/TestWidgets/frontendComponent-TestWidget2/js/applicationScript.js
+++ b/TestWidgets/frontendComponent-TestWidget2/js/applicationScript.js
@@ -52,7 +52,7 @@ var init = function () {
 
 var iwcCallback = function (intent) {
   // define your reactions on incoming iwc events here 
-  if (intent.action == "update" && intent.receiver == $("head").find("title")[0].text) {
+  if (intent.action == "update" && intent.receiver == IWC.util.Self) {
     updateContent(intent.data);
   }
 };

--- a/TestWidgets/frontendComponent-TestWidget2/js/lib/iwc.js
+++ b/TestWidgets/frontendComponent-TestWidget2/js/lib/iwc.js
@@ -172,7 +172,7 @@
 			console.log(intent);
 			var frames = $(".widget", parent.document).find("iframe");
 			frames.each(function () {
-				if ($(this).contents().find("head").find("title").text() === intent.receiver) {
+				if ($('.widget-title-bar', this.offsetParent).find('span').text() === intent.receiver) {
 					this.contentWindow.postMessage(intent, origin);
 				}
 			});
@@ -232,6 +232,11 @@
 			}
 			return true;
 		};
+
+		/**
+		 * Contains the title of the widget
+		 */
+		IWC.util.Self = $('.widget-title-bar', frameElement.offsetParent).find('span').text();
 
 		return IWC;
 	}

--- a/TestWidgets/frontendComponent-TestWidget2/widget.xml
+++ b/TestWidgets/frontendComponent-TestWidget2/widget.xml
@@ -58,7 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>ReceiveWidget</title>
+  <title>ReceiveWidget(Not used for IWC)</title>
 
   <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/iwc.js
+++ b/iwc.js
@@ -172,7 +172,7 @@
 			console.log(intent);
 			var frames = $(".widget", parent.document).find("iframe");
 			frames.each(function () {
-				if ($(this).contents().find("head").find("title").text() === intent.receiver) {
+				if ($('.widget-title-bar', this.offsetParent).find('span').text() === intent.receiver) {
 					this.contentWindow.postMessage(intent, origin);
 				}
 			});
@@ -232,6 +232,11 @@
 			}
 			return true;
 		};
+
+		/**
+		 * Contains the title of the widget
+		 */
+		IWC.util.Self = $('.widget-title-bar', frameElement.offsetParent).find('span').text();
 
 		return IWC;
 	}


### PR DESCRIPTION
Hi Jonas, 

I  found a way to use the widget title for IWC instead of the title in the header of the html part.
I integrated the new iwc library in syncmeta for the local iwc and it seems to work fine so far. 

Best, 
Mario