### PR TITLE
Added required organization scope to package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "iwc",
+  "name": "@rwth-acis/iwc",
   "version": "1.0.0",
   "description": "This contains JS libraries for interwidget communication and las2peer connectivity.",
   "repository": {


### PR DESCRIPTION
To publish the package to our organization, the package name needs to contain "@rwth-acis" as a scope.
That was missing in the last pull request.